### PR TITLE
fix: :bug: fixes the filename of exit_ffi and its export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ erl_crash.dump
 /node_modules
 
 build.tmp
+
+# temporary
+/dist

--- a/src/exit_ffi.mjs
+++ b/src/exit_ffi.mjs
@@ -4,6 +4,6 @@
  * @param {number} code - The exit code to use.
  * @return {void} This function does not return anything.
  */
-function os_exit(code) {
+export function os_exit(code) {
     process.exit(code);
 }


### PR DESCRIPTION
At build time, bun gave the following error:
```
error: Could not resolve: "./exit_ffi.mjs"
    at C:\Users\0erty\Repos\random_git\build\dev\javascript\random_git\utils.mjs:3:33
FileNotFound opening root directory ".\dist"
```
I fixed it by renaming `exit.mjs` to `exit_ffi.mjs`.


Then, got this error:
```
error: No matching export in "build/dev/javascript/random_git/exit_ffi.mjs" for import "os_exit"
    at C:\Users\0erty\Repos\random_git\build\dev\javascript\random_git\utils.mjs:3:10
```
I fixed it by exporting the `os_exit` function.